### PR TITLE
Add feature to allow output to a Markdown file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ Icon
 /packages/
 
 # Test Results
-TestResults/
+TestResults/*
 *.coverage
 *.coveragexml
 


### PR DESCRIPTION
This pull request introduces significant updates to the `New-LLMRequest` and `Invoke-StreamingRequest` functions in the `OpenRouterPS.psm1` file. The primary enhancements include adding the ability to save responses to a Markdown file and suppressing console output when saving to a file. Below are the key changes:

### Enhancements to `New-LLMRequest` function:

* Added `OutFile` parameter to specify the path for saving responses to a Markdown file. When this parameter is used, console output is suppressed unless the `Return` parameter is also specified. [[1]](diffhunk://#diff-3b544d34b883ba87a2d01c5f697d0f6dcbebb7f3b314e9de3662d640e28981a1R119-R122) [[2]](diffhunk://#diff-3b544d34b883ba87a2d01c5f697d0f6dcbebb7f3b314e9de3662d640e28981a1L154-R163)
* Modified examples to demonstrate the usage of the new `OutFile` parameter.
* Implemented logic to handle response content and write it to the specified Markdown file. This includes creating the necessary directories if they do not exist and ensuring the response is saved in the correct format.

### Enhancements to `Invoke-StreamingRequest` function:

* Added `SuppressOutput` parameter to collect output without writing it to stdout, which is useful when saving the response to a file. [[1]](diffhunk://#diff-3b544d34b883ba87a2d01c5f697d0f6dcbebb7f3b314e9de3662d640e28981a1R300-R301) [[2]](diffhunk://#diff-3b544d34b883ba87a2d01c5f697d0f6dcbebb7f3b314e9de3662d640e28981a1L252-R318)
* Updated the streaming logic to conditionally write to stdout based on the `SuppressOutput` parameter. [[1]](diffhunk://#diff-3b544d34b883ba87a2d01c5f697d0f6dcbebb7f3b314e9de3662d640e28981a1L330-R399) [[2]](diffhunk://#diff-3b544d34b883ba87a2d01c5f697d0f6dcbebb7f3b314e9de3662d640e28981a1R412-R414)